### PR TITLE
opster.command with empty argv list

### DIFF
--- a/opster.py
+++ b/opster.py
@@ -143,7 +143,8 @@ class Dispatcher(object):
                                 None):
                         options_.append(o)
 
-                argv = argv or sys.argv[1:]
+                if argv is None:
+                    argv = sys.argv[1:]
                 try:
                     args, opts = process(argv, options_)
                 except Exception, e:


### PR DESCRIPTION
Hi, again. 

Thanks for fixing and incorporating the patches I sent. I'm having a go at a fork+pull this time, since I realise that this is the proper way to send a patch.

I came across the following behaviour whilst writing some py.test style tests for opster (that I'll upload soon).

If you write a script like the following:

```
import opster

@opster.command()
def main(arg=None):
    if arg:
        print arg

main.command([])
```

Then since main.command always receives an empty argument list the script should always do nothing. However, if you run the script with a single argument it will print it out, e.g.:

```
$ ./script.py asd
asd
```

This is because, if an empty argument list is supplied to `main.command`, `sys.argv` will be used (instead of the empty argument list). The commit in this pull request changes that.

Thanks again,
Oscar.
