### PR TITLE
check 'ansi' in ENCODING

### DIFF
--- a/opster.py
+++ b/opster.py
@@ -16,7 +16,8 @@ __email__ = 'alexander@solovyov.net'
 try:
     import locale
     ENCODING = locale.getpreferredencoding()
-    if not ENCODING or ENCODING == 'mac-roman' or 'ascii' in ENCODING.lower():
+    if not ENCODING or ENCODING == 'mac-roman' or 'ascii' in ENCODING.lower()\
+        or 'ansi' in ENCODING.lower():
         ENCODING = 'UTF-8'
 except locale.Error:
     ENCODING = 'UTF-8'

--- a/opster.py
+++ b/opster.py
@@ -16,8 +16,8 @@ __email__ = 'alexander@solovyov.net'
 try:
     import locale
     ENCODING = locale.getpreferredencoding()
-    if not ENCODING or ENCODING == 'mac-roman' or 'ascii' in ENCODING.lower()\
-        or 'ansi' in ENCODING.lower():
+    if (not ENCODING or ENCODING == 'mac-roman' or 'ascii' in ENCODING.lower()
+        or 'ansi' in ENCODING.lower()):
         ENCODING = 'UTF-8'
 except locale.Error:
     ENCODING = 'UTF-8'


### PR DESCRIPTION
With this commit and your last commit the tests will run successfully on my machine.

It seems `ANSI_X3.4-1968` is a particular version of ascii. I don't know why it tries to use that when running the cram tests (I've always used UTF-8 for everything).

I don't know whether any other encodings would exist that have 'ANSI' in the name but would be unsuitable for 'UTF-8'.

Hopefully these issues will be easier in py3k.

Thanks,
Oscar.
