### PR TITLE
Added support for coverage with cram tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ MANIFEST
 dist/
 opster.egg-info/
 tests/*.t.err
+tests/coverage.db
+tests/htmlcov

--- a/tests/.coveragerc
+++ b/tests/.coveragerc
@@ -1,0 +1,18 @@
+# .coveragerc to control coverage.py
+[run]
+branch = True
+data_file = coverage.db
+
+[report]
+# Regexes for lines to exclude from consideration
+exclude_lines =
+    # Have to re-enable the standard pragma
+    pragma: no cover
+
+    # Don't complain if non-runnable code isn't run:
+    if __name__ == .__main__.:
+
+ignore_errors = True
+
+[html]
+directory = htmlcov

--- a/tests/opster.t
+++ b/tests/opster.t
@@ -17,7 +17,13 @@ Define function to make it simpler::
   $ run() {
   >   name=$1
   >   shift
-  >   PYTHONPATH=$TESTDIR/../ python "$TESTDIR/$name" "$@"
+  >   export PYTHONPATH=$TESTDIR/../
+  >   export COVERAGE_FILE=$TESTDIR/coverage.db
+  >   if [ -z "$COVERAGE" ]; then
+  >      python "$TESTDIR/$name" "$@"
+  >   else
+  >      coverage run -a --rcfile="$TESTDIR/.coveragerc" "$TESTDIR/$name" "$@"
+  >   fi
   > }
 
 Main characters:


### PR DESCRIPTION
Hi again.

I'm just beginning to understand how cram works. I wondered how to perform test coverage measurement. Does opster already have a test coverage scheme? This patch implements coverage measurement, using Ned Batchelder's coverage.py, like so:

```
$ coverage erase
$ COVERAGE=1 cram opster.t
.
# Ran 1 tests, 0 skipped, 0 failed.
$ coverage report
Name                                      Stmts   Miss Branch BrPart  Cover
---------------------------------------------------------------------------
/stuff/oscar/work/current/opster/opster     418     77    201     32    82%
hello                                         5      0      2      0   100%
multicommands                                43     10     14      2    79%
multivalueserr                                6      0      0      0   100%
selfhelp                                      6      1      2      1    75%
test_opts                                     5      0      0      0   100%
---------------------------------------------------------------------------
TOTAL                                       483     88    219     35    82%
```

You can also do `coverage html` to generate the html files annotating the code in the `tests/htmlcov` directory.
