### PR TITLE
Added command.Error for fatal error handling

### DIFF
--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -247,4 +247,30 @@ function object, i.e.::
 
 See `an example from the tests`_.
 
+Error messages
+==============
+
+Opster provides a mechanism to quit out of script execution returning a
+message to the user: simply raise ``command.Error`` at any point. Opster will
+catch the error and display its message to the script user. For example::
+
+  from opster import command
+
+  @command()
+  def main(algorithm=('a', 'fast', 'algorithm: slow or fast')):
+      '''
+      script that uses two possible algorithms.
+      '''
+      if algorithm not in ('short', 'fast'):
+          raise command.Error('unrecognised algorithm "{0}"'.format(algorithm))
+      pass
+
+  if __name__ == "__main__":
+      main.command()
+
+Now we can do::
+
+  > python quit.py --algorithm=quick
+  unrecognised algorithm "quick"
+
 .. _example from tests: http://hg.piranha.org.ua/opster/file/default/tests/selfhelp.py

--- a/opster.py
+++ b/opster.py
@@ -819,6 +819,13 @@ class ParseError(OpsterError):
     'Raised on error in command line parsing'
 
 
+class QuitError(OpsterError):
+    'Raised to exit script with a message to the user'
+
+# API to expose QuitError for opster users
+command.Error = QuitError
+
+
 if __name__ == '__main__':
     import doctest
     doctest.testmod()

--- a/tests/opster.t
+++ b/tests/opster.t
@@ -249,5 +249,10 @@ keyword argument 'option'``::
   $ run multivalueserr.py some arguments hehe
   I work! False bopt some arguments ('hehe',)
 
+Scripts can exit with an error message at any time by raising
+``command.Error``::
+
+  $ run quit.py --algorithm=quick
+  unrecognised algorithm "quick"
 
 That's all for today; see you next time!

--- a/tests/quit.py
+++ b/tests/quit.py
@@ -1,0 +1,13 @@
+from opster import command
+
+@command()
+def main(algorithm=('a', 'fast', 'algorithm: slow or fast')):
+    '''
+    script that uses two possible algorithms.
+    '''
+    if algorithm not in ('short', 'fast'):
+        raise command.Error('unrecognised algorithm "{0}"'.format(algorithm))
+    pass
+
+if __name__ == "__main__":
+    main.command()


### PR DESCRIPTION
As promised.

The only thing I'm wondering is if a message should be printed prompting the user to use '-h' or '--help'. This would often but not always be appropriate.
