### PR TITLE
Proposed fix for GH-2

### DIFF
--- a/opster.py
+++ b/opster.py
@@ -139,10 +139,13 @@ class Dispatcher(object):
 
             def command(argv=None):
                 for o in self.globaloptions:
-                    if not next((x for x in options_ if
-                                 x[1] == o[1] or (x[0] and x[0] == o[0])),
-                                None):
-                        options_.append(o)
+                    # Don't include global option if long name matches
+                    if any((x[1] == o[1] for x in options_)):
+                        continue
+                    # Don't use global option short name if already used
+                    if any((x[0] and x[0] == o[0] for x in options_)):
+                        o = ('',) + o[1:]
+                    options_.append(o)
 
                 if argv is None:
                     argv = sys.argv[1:]

--- a/tests/ls.py
+++ b/tests/ls.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python
+
+import sys
+from opster import command
+
+@command(usage='[-h]')
+def main(human=('h', False, 'Pretty print filesizes')):
+    if human:
+        print '26k'
+    else:
+        print '26037'
+
+if __name__ == "__main__":
+    main.command(sys.argv[1:])

--- a/tests/opster.t
+++ b/tests/opster.t
@@ -265,3 +265,16 @@ There is no problems with handling variable argumentrs and underscores::
   {'args': ('var1', 'var2'), 'test_option': 'test1'}
   $ run varargs.py var1 var2
   {'args': ('var1', 'var2'), 'test_option': 'test'}
+
+We can have an option that uses the '-h' short name (although we use it as a
+short name for '--help'::
+
+  $ run ls.py --help
+  ls.py [-h]
+  
+  (no help text available)
+  
+  options:
+  
+   -h --human  Pretty print filesizes
+      --help   display help


### PR DESCRIPTION
Hi,

This patch changes the way that globaloptions are merged into opts. The result is that options can use '-h' in the obvious way (see the test script) without disabling '--help'. This should fix GH-2.

The old behaviour was to refuse to include any global option if either its long or short name conflicted with another option. The result of this is that an option with short name '-h' would prevent the help option from being added to the command (I didn't get the stacktrace reported in GH-2).

With this patch the new behaviour is to refuse to include a global option if its long name matches any local option (since these are definitely not compatible). If the short name matches, then the short name is used for the local option. This means that if an option declares '-h', then '--help' will still be available but '-h' will refer to the new option.

In the general case when using dispatch this behaviour could lead to unexpected results where for example the short name for a global option would have a different meaning in some subcommands. However, if someone is overriding the short name of a global option in a local option I can't see what other behaviour they should expect.

Thanks,
Oscar.
