### PR TITLE
Make oldapi.py py3k-compatible

### DIFF
--- a/tests/oldapi.py
+++ b/tests/oldapi.py
@@ -8,14 +8,14 @@ from opster import dispatch
 cmd1opts = [('q', 'quiet', False, 'be quiet')]
 def cmd1(**opts):
     if not opts['quiet']:
-        print 'Not being quiet!'
+        print('Not being quiet!')
 
 cmd2opts = [('v', 'verbose', False, 'be loud')]
 def cmd2(arg, *args, **opts):
-    print arg
+    print(arg)
     if opts['verbose']:
         for arg in args:
-            print arg
+            print(arg)
 
 cmdtable = {
     'cmd1':(cmd1, cmd1opts, '[-q|--quiet]'),


### PR DESCRIPTION
Makes the test run with `make test2to3`
