### PR TITLE
Add support for keyword-only arguments in py3k

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,17 +23,18 @@ arch:
 
 test:
 	python opster.py
-	$(CRAM) tests/*.t
+	$(CRAM) tests/opster.t
 
 test2to3:
 	"$(PYTHON3)" setup.py build
 	2to3 --doctests_only --write "$(BUILD_DIR)"/opster.py
 	"$(PYTHON3)" "$(BUILD_DIR)"/opster.py
-	PYTHON="$(PYTHON3)" OPSTER_DIR="$(BUILD_DIR)" $(CRAM) tests/*.t
+	PYTHON="$(PYTHON3)" OPSTER_DIR="$(BUILD_DIR)" $(CRAM) tests/opster.t
+	PYTHON="$(PYTHON3)" OPSTER_DIR="$(BUILD_DIR)" $(CRAM) tests/py3k.t
 
 coverage:
 	coverage run -a opster.py
-	COVERAGE=1 $(CRAM) tests/*.t
+	COVERAGE=1 $(CRAM) tests/opster.t
 
 upload:
 	python setup.py sdist upload

--- a/tests/kwonly.py
+++ b/tests/kwonly.py
@@ -1,0 +1,9 @@
+from opster import command
+
+@command()
+def main(arg1, arg2=None, *,
+         opt1=('', 'opt1', 'help for --opt1')):
+    print(arg1, arg2)
+    print(opt1)
+
+main.command()

--- a/tests/kwonlyvarargs.py
+++ b/tests/kwonlyvarargs.py
@@ -1,0 +1,11 @@
+from opster import command
+
+@command()
+def main(arg1, arg2, arg3=None, arg4='arg4', *args,
+         opt1=('', 'opt1', 'help for --opt1'),
+         opt2=('', 'opt2', 'help for --opt2')):
+    print(arg1, arg2, arg3, arg4)
+    print(args)
+    print(opt1, opt2)
+
+main.command()

--- a/tests/py3k.t
+++ b/tests/py3k.t
@@ -1,0 +1,143 @@
+.. -*- mode: rst -*-
+
+==================
+ Opster Py3K tests
+==================
+
+This is the opster test suite for tests that are only to be run on python 3.x
+
+.. highlight:: console
+
+Actors cast
+-----------
+
+Choose python version::
+
+  $   if [ -z "$PYTHON" ]; then
+  >      PYTHON="python"
+  >   fi
+
+Add opster to the PYTHONPATH::
+
+  $   if [ -z "$OPSTER_DIR" ]; then
+  >      OPSTER_DIR="$TESTDIR/.."
+  >   fi
+  >   export PYTHONPATH="$OPSTER_DIR"
+
+Define function to make it simpler::
+
+  $ run() {
+  >   name=$1
+  >   shift
+  >   export COVERAGE_FILE=$TESTDIR/coverage.db
+  >   if [ -z "$COVERAGE" ]; then
+  >      "$PYTHON" "$TESTDIR/$name" "$@"
+  >   else
+  >      coverage run -a --rcfile="$TESTDIR/../.coveragerc" "$TESTDIR/$name" "$@"
+  >   fi
+  > }
+
+Keyword-only args
+-----------------
+
+Check that opster understand keyword-only args when used without varargs.
+
+  $ run kwonly.py
+  kwonly.py: invalid arguments
+  
+  kwonly.py [OPTIONS] ARG1 [ARG2]
+  
+  (no help text available)
+  
+  options:
+  
+      --opt1  help for --opt1 (default: opt1)
+   -h --help  display help
+
+  $ run kwonly.py A
+  A None
+  opt1
+
+  $ run kwonly.py A B
+  A B
+  opt1
+
+  $ run kwonly.py A B C
+  kwonly.py: invalid arguments
+  
+  kwonly.py [OPTIONS] ARG1 [ARG2]
+  
+  (no help text available)
+  
+  options:
+  
+      --opt1  help for --opt1 (default: opt1)
+   -h --help  display help
+
+  $ run kwonly.py A --opt1=newval
+  A None
+  newval
+
+  $ run kwonly.py A B --opt1=newval
+  A B
+  newval
+
+  $ run kwonly.py A B C --opt1=newval
+  kwonly.py: invalid arguments
+  
+  kwonly.py [OPTIONS] ARG1 [ARG2]
+  
+  (no help text available)
+  
+  options:
+  
+      --opt1  help for --opt1 (default: opt1)
+   -h --help  display help
+
+Keyword-only args and varargs
+-----------------------------
+
+Check that opster understand keyword-only args when used with varargs.
+
+  $ run kwonlyvarargs.py
+  kwonlyvarargs.py: invalid arguments
+  
+  kwonlyvarargs.py [OPTIONS] ARG1 ARG2 [ARG3] [ARG4] [ARGS ...]
+  
+  (no help text available)
+  
+  options:
+  
+      --opt1  help for --opt1 (default: opt1)
+      --opt2  help for --opt2 (default: opt2)
+   -h --help  display help
+
+  $ run kwonlyvarargs.py A B
+  A B None arg4
+  ()
+  opt1 opt2
+
+  $ run kwonlyvarargs.py A B C D
+  A B C D
+  ()
+  opt1 opt2
+
+  $ run kwonlyvarargs.py A B C D E F
+  A B C D
+  ('E', 'F')
+  opt1 opt2
+
+  $ run kwonlyvarargs.py A B --opt1=newval --opt2=newval2
+  A B None arg4
+  ()
+  newval newval2
+
+  $ run kwonlyvarargs.py A B C D --opt1=newval1 --opt2=newval2
+  A B C D
+  ()
+  newval1 newval2
+
+  $ run kwonlyvarargs.py A B C D E F --opt1=newval1 --opt2=newval2
+  A B C D
+  ('E', 'F')
+  newval1 newval2


### PR DESCRIPTION
Hi again.

This patch adds support and tests for keyword-only arguments in functions wrapped by `@command`. I had to modify the makefile and create a new .t file so that there could be tests that would only run for python3.

Python 3 supports keyword only arguments. If these had been available when opster was written it would definitely have made sense to use them. This way, you can write:

```
@command()
def main(*args, opt1=('o', False, 'first option')):
    pass
```

This means that opster can easily distinguish positional arguments and keyword arguments (since there is no overlap). It means that opster does not need to check the type (`isinstance(default, tuple)`) in order to identify an option argument. It also means that the `command` decorator does not even need to wrap the `main` function and could just return it with the default values modified (no need for `call_cmd_regular`). Finally, it makes the code clearer even if `*args` is not used, e.g.:

```
@command()
def main(arg1, arg2=None, *,
         opt1=('o', False, 'first option')):
    pass
```

Keyword-only arguments are only supported in python3. Also `inspect.getargspec` is deprecated in python3 and raises `ValueError` if its input has keyword-only arguments. This makes it a bit fiddly to support both cases simultaneously. The current patch will assume if the function has any keyword only arguments that all of them are for options (and that all other arguments are positional).

If python2.x stops being supported for new opster releases, I think it would be good to drop support for using argument inspection without keyword-only arguments so that in future all opster scripts written on python3 use keyword-only arguments.

Cheers,
Oscar.
