### PR TITLE
Add support for arbitrary option types

### DIFF
--- a/opster.py
+++ b/opster.py
@@ -424,8 +424,7 @@ def Option(opt):
 
     # Find matching _Option subclass and return instance
     # nb. the order of testing matters
-    for Type in (BoolOption, IntOption, FloatOption, ListOption,
-                 DictOption, FuncOption, LiteralOption):
+    for Type in (BoolOption, ListOption, DictOption, FuncOption, BaseOption):
         if Type.matches(default):
             return Type(*args)
     raise OpsterError('Cannot figure out type for option %s' % name)
@@ -441,7 +440,7 @@ def CmdTable(cmdtable):
 class BaseOption(namedtuple('Option', (
             'pyname', 'name', 'short', 'default', 'helpmsg', 'completer'))):
     has_parameter = True
-    type = None
+    type = object
 
     def __repr__(self):
         return (super(BaseOption, self).__repr__()
@@ -462,19 +461,11 @@ class BaseOption(namedtuple('Option', (
 
     def convert(self, final):
         '''Generate the resulting python value from the final state.'''
-        return self.type(final)
+        return type(self.default)(final)
 
     def default_value(self):
         '''Shortcut to obtain the default value when option arg not provided.'''
         return self.convert(self.default_state())
-
-
-class LiteralOption(BaseOption):
-    '''Literal option type (including string options, no processing).'''
-    type = object
-
-    def convert(self, final):
-        return final
 
 
 class BoolOption(BaseOption):
@@ -487,16 +478,6 @@ class BoolOption(BaseOption):
 
     def update_state(self, state, new):
         return not self.default
-
-
-class IntOption(BaseOption):
-    '''Integer number option type.'''
-    type = int
-
-
-class FloatOption(BaseOption):
-    '''Floating point number option type.'''
-    type = float
 
 
 class ListOption(BaseOption):

--- a/tests/ls.py
+++ b/tests/ls.py
@@ -1,16 +1,19 @@
 #!/usr/bin/env python
 
 import sys
+from decimal import Decimal as D
 from opster import command
 
 @command(usage='[-h]')
 def main(human=('h', False, 'Pretty print filesizes'),
+         filesize=('f', D('26037'), 'size to print'),
          nohelp1=('', False, ''),
          nohelp2=('n', False, '')):
+    print(type(filesize))
     if human:
-        print('26k')
+        print(str(filesize // 1024) + 'k')
     else:
-        print('26037')
+        print(filesize)
 
 if __name__ == "__main__":
     main.command(sys.argv[1:], scriptname='ls')

--- a/tests/opster.t
+++ b/tests/opster.t
@@ -392,10 +392,11 @@ short name for '--help'::
   
   options:
   
-   -h --human  Pretty print filesizes
+   -h --human     Pretty print filesizes
+   -f --filesize  size to print (default: 26037)
       --nohelp1
    -n --nohelp2
-      --help   display help
+      --help      display help
 
 Let's just check that the scriptname argument ``scriptname='ls'`` works as
 expected for the error messages::
@@ -409,10 +410,11 @@ expected for the error messages::
   
   options:
   
-   -h --human  Pretty print filesizes
+   -h --human     Pretty print filesizes
+   -f --filesize  size to print (default: 26037)
       --nohelp1
    -n --nohelp2
-      --help   display help
+      --help      display help
 
   $ run ls.py --invalid
   error: option --invalid not recognized
@@ -423,10 +425,18 @@ expected for the error messages::
   
   options:
   
-   -h --human  Pretty print filesizes
+   -h --human     Pretty print filesizes
+   -f --filesize  size to print (default: 26037)
       --nohelp1
    -n --nohelp2
-      --help   display help
+      --help      display help
+
+Now lets check that opster gets the type of the --filesize option correct
+(should be decimal.Decimal)::
+
+  $ run ls.py --filesize=12345 -h
+  <class 'decimal.Decimal'>
+  12k
 
 
 We can also supply the ``scriptname`` argument to ``dispatch``::


### PR DESCRIPTION
This patch adds support and 1 test for using arbitrary option types in opster. Previous version of opster supported this, although I'm not sure if it was intentional since it was never documented.

Essentially, opster can create option instances of any type by doing `optval = type(optdefault)(optarg)`. This works for LiteralOption, IntOption and FloatOption (making each of those types redundant if it is the default behaviour for BaseOption). Allowing this in general for BaseOption and allowing BaseOption to match against object ensures that arbitrary types can be supported as option types provided the type can be created from a string. For example, we can have a script like:

```
#!/usr/bin/env python

from decimal import Decimal
from fractions import Fraction
import opster

@opster.command()
def main(x=('f', Decimal('1'), 'decimal number'),
         y=('h', Fraction('1/2'), 'fraction number')):
    print x, type(x)
    print y, type(y)

main.command()
```

Then the script can be used like

```
$ ./script.py --x=.3 --y='9/16'
0.3 <class 'decimal.Decimal'>
9/16 <class 'fractions.Fraction'>
```

The other implication of doing this on python 2.x is that if the default option values was a unicode string that the input argument will be converted to a unicode string by opster. Perhaps it would be better to add the `LiteralOption` in again for clarity even if it is redundant (although the previous version would have ignored the type of unicode arguments when processing option values).

With this patch only the types `bool`, `list`, `dict` and `Callable` are special cased.

Is this desirable behaviour for opster? I used it with `decimal.Decimal` a few times since it worked with previous opster versions, but I don't think it was ever documented (although I think the code in the old version of `process()` was written with this kind of usage in mind).
