### PR TITLE
Unicode option

### DIFF
--- a/opster.py
+++ b/opster.py
@@ -485,7 +485,9 @@ class UnicodeOption(BaseOption):
     type = unicode
 
     def convert(self, final):
-        return final.decode(ENCODING)
+        if sys.version_info < (3, 0):
+            final = final.decode(ENCODING)
+        return final
 
 
 class BoolOption(BaseOption):

--- a/tests/hello.py
+++ b/tests/hello.py
@@ -1,9 +1,13 @@
+import sys
 from opster import command
+
+unicode = unicode if sys.version_info < (3, 0) else str
+out = getattr(sys.stdout, 'buffer', sys.stdout)
 
 @command()
 def hello(name,
           times=1,
-          greeting=('g', u'Hello', 'Greeting to use')):
+          greeting=('g', unicode('Hello'), 'Greeting to use')):
     """
     Hello world continues the long established tradition
     of delivering simple, but working programs in all
@@ -12,11 +16,11 @@ def hello(name,
     This tests different docstring formatting (just text instead of having
     subject and body).
     """
-    if isinstance(name, str):
+    if hasattr(name, 'decode'):
         name = name.decode('utf-8')
     # no parsing for optional arguments yet :\
     for i in range(int(times)):
-        print((u"%s %s" % (greeting, name)).encode('utf-8'))
+        out.write((unicode("%s %s\n") % (greeting, name)).encode('utf-8'))
 
 if __name__ == "__main__":
     hello.command()


### PR DESCRIPTION
This fixes some of the tests with `make test2to3`. Unicode literals are not allowed in python 3.1 or 3.2.     Also str objects in python 3.x don't have decode methods (since they are already unicode).

```
I'm still getting one error though:

--- q:\current\opster\tests\opster.t
+++ q:\current\opster\tests\opster.t.err
@@ -363,7 +363,7 @@
 And there is no problems handling unicode data::

   $ run hello.py ð║ÐÇð¥Ðüð░ð▓ÐçðÁð│ -g ðƒÐÇð©ð▓ðÁÐé
-  \xd0\x9f\xd1\x80\xd0\xb8\xd0\xb2\xd0\xb5\xd1\x82         \xd0\xba\xd1\x80\xd0\xbe\xd1\x81\xd0\xb0\xd0\xb2\xd1\x87\xd0\xb5\xd0\xb3 (esc)
+      \xc3\x90\xc5\xb8\xc3\x91\xe2\x82\xac\xc3\x90\xc2\xb8\xc3\x90\xc2\xb2\xc3\x90\xc2\xb5\xc3\x91\xe2\x    80\x9a     \xc3\x90\xc2\xba\xc3\x91\xe2\x82\xac\xc3\x90\xc2\xbe\xc3\x91\xc2\x81\xc3\x90\xc2\xb0\xc3\x90\xc2\x    b2\xc3\x91\xe2\x80\xa1\xc3\x90\xc2\xb5\xc3\x90\xc2\xb3 (esc)


 .. _multivalues:

# Ran 1 tests, 0 skipped, 1 failed.
make: *** [test2to3] Error 1
```

I don't know enough about unicode to understand what has happened there.
