### PR TITLE
Use 'surrogateescape' to decode input arguments

### DIFF
--- a/opster.py
+++ b/opster.py
@@ -25,6 +25,21 @@ except locale.Error:
     ENCODING = 'UTF-8'
 
 _writer = codecs.getwriter(ENCODING)
+FSE_ENCODING = sys.getfilesystemencoding()
+
+
+def decodearg(arg, encoding=ENCODING):
+    '''Decode an input argument as encoding'''
+    # python 2.x: have bytes, convert to unicode with given encoding
+    if sys.version_info < (3, 0):
+        return arg.decode(ENCODING)
+    # python 3.x: have unicode (perhaps with surrogate escape)
+    # arg has already been decoded with FSE_ENCODING
+    else:
+        # Invert implicit decoding done by python
+        arg_raw = arg.encode(FSE_ENCODING, 'surrogateescape')
+        # Re-decode as desired encoding
+        return arg_raw.decode(ENCODING)
 
 
 def write(text, out=None):
@@ -480,14 +495,13 @@ class LiteralOption(BaseOption):
         else:
             return type(self.default)(final)
 
+
 class UnicodeOption(BaseOption):
     '''Handle unicode values, decoding input'''
     type = unicode
 
     def convert(self, final):
-        if sys.version_info < (3, 0):
-            return final.decode(ENCODING)
-        return final
+        return decodearg(final)
 
 
 class BoolOption(BaseOption):

--- a/tests/hello.py
+++ b/tests/hello.py
@@ -1,5 +1,5 @@
 import sys
-from opster import command
+from opster import command, decodearg
 
 # This could seem to be a little involved, but keep in mind that those little
 # movements here are done to support both python 2.x and 3.x
@@ -18,11 +18,12 @@ def hello(name,
     This tests different docstring formatting (just text instead of having
     subject and body).
     """
-    if hasattr(name, 'decode'):
-        name = name.decode('utf-8')
+    # opster should somehow do this automatically:
+    name = decodearg(name, 'utf-8')
+
     # no parsing for optional arguments yet :\
     for i in range(int(times)):
-        out.write((unicode("%s %s\n") % (greeting, name)).encode('utf-8'))
+        out.write(unicode("{0} {1}\n").format(greeting, name).encode('utf-8'))
 
 if __name__ == "__main__":
     hello.command()


### PR DESCRIPTION
Ok, so I've found the fix for input argument decoding. The problem is described in pep-383 that also provides the solution:
http://www.python.org/dev/peps/pep-0383/

This patch fixes the tests under python 2.6 and 3.1.

In python3 `sys.argv` needs to be a list of unicode strings. When the python interpreter starts up, python takes the raw bytes arguments provided to the interpreter and decodes them using a system-dependent encoding. If I understand correctly, then the encoding used is always available as `sys.getfilesystemencoding()`. I think the reason for using the filesystem encoding is that the most common problem caused by incorrect argument encoding is incorrect representation of file paths. The reason the tests failed for me was because on windows the filesystem encoding is not utf-8.

The input arguments, given as raw bytes in c, may contain characters that don't exist in the encoding that python uses to decode them. So python uses the `surrogate escape` feature described in pep-383 to decode the arguments in a way that can at least be inverted. The raw argument as a bytes object can be obtained using:

```
raw_arg = arg.encode(sys.getfilesystemencoding(), 'surrogateescape')
```

We wanted to decode the argument as `desired_encoding`, so then we do

```
arg = raw_arg.decode(desired_encoding)
```

In python 2.x only the second step is necessary since the interpreter will give us the raw bytes as a `str`.

This is pretty confusing and it would be good if opster can save its users from ever having to know about it, by doing it automatically: opster could just do this to all arguments all the time. However, I don't think that would work for arguments that had never been decoded in this way. For example under python 3.x, if someone generates a list of arguments in python and passes them to `main.command` opster cannot know if that list of arguments was generated from the entries in `sys.argv` or was generated programmatically:

If someone calls main.command or d.dispatch with no arguments opster knows that it is getting the arguments from sys.argv and can do the surrogateescape fix. However opster doesn't know what encoding the script writer really wanted to use (if not the filesystem encoding):

```
 main.command()
 d.dispatch()
```

If someone passes a list of arguments in, opster cannot presume to be able to get anything sensible by encoding the arguments and then decoding them as a different encoding. Probably opster should just leave them

```
main.command(['my', 'list', 'of', 'args'])
```

But then how can opster spot this:

```
main.command(sys.argv[1:])
```

If opster will automatically decode the arguments then there should be a documented way to tell opster what encoding you want to decode them as

```
opster.ENCODING = 'cp850'
```

Perhaps the simplest thing is for opster to just provide an API function similar to `decodearg` in this patch. Then it can be used like in `hello.py` in this patch.
