### PR TITLE
Remove positional arguments length check when calling command as python ...

### DIFF
--- a/opster.py
+++ b/opster.py
@@ -857,9 +857,6 @@ def call_cmd_regular(func, opts):
     '''
     def inner(*args, **kwargs):
         arginfo = inspect.getargspec(func)
-        if len(args) > len(arginfo.args):
-            raise TypeError('You have supplied more positional arguments'
-                            ' than applicable')
 
         # short name, long name, default, help, (maybe) completer
         funckwargs = dict((o.pyname, o.default) for o in opts)


### PR DESCRIPTION
...function

Example fails without this change:

import opster

@opster.command()
def main(_args, *_kwargs):
    print args, kwargs

main('foo', bar='baz')
