### PR TITLE
Fix varargs handling when main is called directly

### DIFF
--- a/tests/opster.t
+++ b/tests/opster.t
@@ -733,3 +733,42 @@ that we can have subsubcommands.
   $ run subcmds.py cmd subcmd3 subsubcmd -l
   running subsubcmd
 
+Check the `varargs` works when calling ```main``` directly::
+
+  $ run varargs_py2.py
+  
+  main():
+  TypeError raised
+  
+  main("a"):
+  shop: a
+  cheeses: ()
+  music: False
+  
+  main("a", "b"):
+  shop: a
+  cheeses: ('b',)
+  music: False
+  
+  main("a", "b", "c"):
+  shop: a
+  cheeses: ('b', 'c')
+  music: False
+  
+  main(music=True):
+  TypeError raised
+  
+  main("a", music=True):
+  shop: a
+  cheeses: ()
+  music: True
+  
+  main("a", "b", music=True):
+  shop: a
+  cheeses: ('b',)
+  music: True
+  
+  main("a", "b", "c", music=True):
+  shop: a
+  cheeses: ('b', 'c')
+  music: True

--- a/tests/py3k.t
+++ b/tests/py3k.t
@@ -141,3 +141,44 @@ Check that opster understand keyword-only args when used with varargs.
   A B C D
   ('E', 'F')
   newval1 newval2
+
+Check the `varargs` works when calling ```main``` directly::
+
+  $ run varargs_py3.py
+  
+  main():
+  TypeError raised
+  
+  main("a"):
+  shop: a
+  cheeses: ()
+  music: False
+  
+  main("a", "b"):
+  shop: a
+  cheeses: ('b',)
+  music: False
+  
+  main("a", "b", "c"):
+  shop: a
+  cheeses: ('b', 'c')
+  music: False
+  
+  main(music=True):
+  TypeError raised
+  
+  main("a", music=True):
+  shop: a
+  cheeses: ()
+  music: True
+  
+  main("a", "b", music=True):
+  shop: a
+  cheeses: ('b',)
+  music: True
+  
+  main("a", "b", "c", music=True):
+  shop: a
+  cheeses: ('b', 'c')
+  music: True
+

--- a/tests/varargs_py2.py
+++ b/tests/varargs_py2.py
@@ -1,0 +1,38 @@
+# varargs_py2.py
+
+from __future__ import print_function
+
+from opster import command
+
+@command()
+def main(shop,
+         music=('m', False, 'provide musical accompaniment'),
+         *cheeses):
+    '''Buy cheese'''
+    print('shop:', shop)
+    print('cheeses:', cheeses)
+    print('music:', music)
+
+if __name__ == "__main__":
+
+    print('\nmain():')
+    try:
+        main()
+    except TypeError:
+        print('TypeError raised')
+
+    for expr in 'main("a")', 'main("a", "b")', 'main("a", "b", "c")':
+        print('\n{0}:'.format(expr))
+        eval(expr)
+
+    print('\nmain(music=True):')
+    try:
+        main(music=True)
+    except TypeError:
+        print('TypeError raised')
+
+    for expr in ('main("a", music=True)',
+                 'main("a", "b", music=True)',
+                 'main("a", "b", "c", music=True)'):
+        print('\n{0}:'.format(expr))
+        eval(expr)

--- a/tests/varargs_py3.py
+++ b/tests/varargs_py3.py
@@ -1,0 +1,38 @@
+# varargs_py3.py
+
+from __future__ import print_function
+
+from opster import command
+
+@command()
+def main(shop,
+         *cheeses,
+         music=('m', False, 'provide musical accompaniment')):
+    '''Buy cheese'''
+    print('shop:', shop)
+    print('cheeses:', cheeses)
+    print('music:', music)
+
+if __name__ == "__main__":
+
+    print('\nmain():')
+    try:
+        main()
+    except TypeError:
+        print('TypeError raised')
+
+    for expr in 'main("a")', 'main("a", "b")', 'main("a", "b", "c")':
+        print('\n{0}:'.format(expr))
+        eval(expr)
+
+    print('\nmain(music=True):')
+    try:
+        main(music=True)
+    except TypeError:
+        print('TypeError raised')
+
+    for expr in ('main("a", music=True)',
+                 'main("a", "b", music=True)',
+                 'main("a", "b", "c", music=True)'):
+        print('\n{0}:'.format(expr))
+        eval(expr)


### PR DESCRIPTION
This is a patch for GH-48.

This patch fixes `call_cmd_regular` to work with varargs when the varargs parameter is placed after the option list, so that this script:

```
@opster()
def main(arg, opt=('o', False, 'option help'), *args):
    print 'arg', arg
    print 'args', args
    print 'opt', opt

main('a', 'b', 'c')
```

will output:

```
arg a
args ('b', 'c')
opt False
```

The patch also adds support for function siw th keyword only arguments in `call_cmd_regular`.
