### PR TITLE
Fix call_cmd_regular when arginfo.defaults is None

### DIFF
--- a/opster.py
+++ b/opster.py
@@ -885,7 +885,7 @@ def call_cmd_regular(func, opts):
         # positional arguments to give a flat positional arg list
         remaining = list(args)
         args = []
-        defaults_offset = len(arginfo.args) - len(arginfo.defaults)
+        defaults_offset = len(arginfo.args) - len(arginfo.defaults or [])
         for n, argname in enumerate(arginfo.args):
             # Option arguments MUST be given as keyword arguments
             if argname in opt_args:

--- a/tests/nodefaults.py
+++ b/tests/nodefaults.py
@@ -1,0 +1,8 @@
+import opster
+
+# arginfo.defaults will be None for this function
+@opster.command()
+def hello():
+    print('hello')
+
+hello()

--- a/tests/opster.t
+++ b/tests/opster.t
@@ -772,3 +772,10 @@ Check the `varargs` works when calling ```main``` directly::
   shop: a
   cheeses: ('b', 'c')
   music: True
+
+
+Check that calling main directly still works even if ```arginfo.defaults``` is
+None::
+
+  $ run nodefaults.py
+  hello


### PR DESCRIPTION
Hi again. Sorry I've been too busy to do anything on opster lately. I did find a bug just now, though, while working on something else.

This patch fixes and adds tests for a bug when calling an opster-wrapped function directly (rather than using the `.command` attribute for a function that doesn't have any arguments with default values..
For whatever reason `inspect.getargspec` can return an `ArgSpec` with `defaults` set to `None` rather than an empty tuple. This patch just adds a quick check for that case.
