### PR TITLE
Fuzzy match the command name

### DIFF
--- a/opster.py
+++ b/opster.py
@@ -2,7 +2,7 @@
 '''Command line arguments parser
 '''
 
-import sys, traceback, getopt, types, textwrap, inspect, os, keyword, codecs
+import sys, traceback, getopt, types, textwrap, inspect, os, re, keyword, codecs
 from itertools import imap
 from functools import wraps
 from collections import namedtuple, Callable
@@ -680,6 +680,7 @@ def aliases_(cmdtable_key):
 def findpossible(cmd, table):
     '''Return cmd -> (aliases, command table entry) for each matching command.
     '''
+    pattern = '.*?'.join(list(cmd))
     choice = {}
     for e in table.keys():
         aliases = aliases_(e)
@@ -688,7 +689,7 @@ def findpossible(cmd, table):
             found = cmd
         else:
             for a in aliases:
-                if a.startswith(cmd):
+                if re.search(pattern, a):
                     found = a
                     break
         if found is not None:


### PR DESCRIPTION
e.g. "cmdpar" would match command named "a-command-part"

While this regexp matching is orders of magnitude slower it is a 3us to
30us difference; i.e. completely lost in the noise of starting the
python process.
